### PR TITLE
Reduce number of lines in Knex Migration file by tightening chained calls

### DIFF
--- a/data/migrations/20200410195204_neighborhood-chef.js
+++ b/data/migrations/20200410195204_neighborhood-chef.js
@@ -2,97 +2,46 @@ exports.up = function(knex) {
   return knex.schema
     .createTable('Users', tbl => {
       tbl.increments();
-      tbl.string('Email', 255)
-        .unique()
-        .notNullable();
-      tbl.string('Password', 128)
-        .notNullable();
-      tbl.string('FirstName', 64)
-        .notNullable();
-      tbl.string('LastName', 64)
-        .notNullable();
+      tbl.string('Email', 255).unique().notNullable();
+      tbl.string('Password', 128).notNullable();
+      tbl.string('FirstName', 64).notNullable();
+      tbl.string('LastName', 64).notNullable();
       tbl.string('Gender', 64);
-      tbl.string('Address', 255)
-        .notNullable();
-      tbl.decimal('Latitude', 9, 6)
-        .notNullable();
-      tbl.decimal('Longitude', 9, 6)
-        .notNullable();
+      tbl.string('Address', 255).notNullable();
+      tbl.decimal('Latitude', 9, 6).notNullable();
+      tbl.decimal('Longitude', 9, 6).notNullable();
       tbl.binary('Photo');
     })
     .createTable('Categories', tbl => {
       tbl.increments();
-      tbl.text('Category')
-        .unique()
-        .notNullable();
+      tbl.text('Category').unique().notNullable();
     })
     .createTable('Events', tbl => {
       tbl.increments();
-      tbl.integer('user_id')
-        .notNullable()
-        .unsigned()
-        .references('Users.id');
-      tbl.date('Date')
-        .notNullable();
-      tbl.time('Start_Time')
-        .notNullable();
+      tbl.integer('user_id').notNullable().unsigned().references('Users.id');
+      tbl.date('Date').notNullable();
+      tbl.time('Start_Time').notNullable();
       tbl.time('End_Time');
-      tbl.string('Title', 255)
-        .notNullable();
-      tbl.text('Description')
-        .notNullable();
+      tbl.string('Title', 255).notNullable();
+      tbl.text('Description').notNullable();
       tbl.binary('Photo');
-      tbl.integer('category_id')
-        .notNullable()
-        .unsigned()
-        .references('Categories.id');
+      tbl.integer('category_id').notNullable().unsigned().references('Categories.id');
       tbl.json('Modifiers');
-      tbl.string('Address', 255)
-        .notNullable();
-      tbl.decimal('Latitude', 9, 6)
-        .notNullable();
-      tbl.decimal('Longitude', 9, 6)
-        .notNullable();
+      tbl.string('Address', 255).notNullable();
+      tbl.decimal('Latitude', 9, 6).notNullable();
+      tbl.decimal('Longitude', 9, 6).notNullable();
     })
     //Bridge Tables below
     .createTable('Events_Attending', tbl => {
-      tbl.integer('event_id')
-        .notNullable()
-        .unsigned()
-        .references('Events.id')
-        .onUpdate('CASCADE')
-        .onDelete('CASCADE');
-      tbl.integer('user_id')
-        .notNullable()
-        .unsigned()
-        .references('Users.id')
-        .onUpdate('CASCADE')
-        .onDelete('CASCADE');
-        tbl.primary(['event_id', 'user_id']);
+      tbl.integer('event_id').notNullable().unsigned().references('Events.id').onUpdate('CASCADE').onDelete('CASCADE');
+      tbl.integer('user_id').notNullable().unsigned().references('Users.id').onUpdate('CASCADE').onDelete('CASCADE');
+      tbl.primary(['event_id', 'user_id']);
     })
     .createTable('Events_Invited', tbl => {
-      tbl.integer('event_id')
-        .notNullable()
-        .unsigned()
-        .references('Events.id')
-        .onUpdate('CASCADE')
-        .onDelete('CASCADE');
-      tbl.integer('user_id')
-        .notNullable()
-        .unsigned()
-        .references('Users.id')
-        .onUpdate('CASCADE')
-        .onDelete('CASCADE');
-      tbl.integer('inviter_id')
-        .notNullable()
-        .unsigned()
-        .references('Users.id')
-        .onUpdate('CASCADE')
-        // .onDelete('CASCADE')
-        ;
-      tbl.boolean('approved')
-        .notNullable()
-        .defaultTo('false');
+      tbl.integer('event_id').notNullable().unsigned().references('Events.id').onUpdate('CASCADE').onDelete('CASCADE');
+      tbl.integer('user_id').notNullable().unsigned().references('Users.id').onUpdate('CASCADE').onDelete('CASCADE');
+      tbl.integer('inviter_id').notNullable().unsigned().references('Users.id').onUpdate('CASCADE');
+      tbl.boolean('approved').notNullable().defaultTo('false');
       tbl.primary(['event_id', 'user_id']);
     })
     ;


### PR DESCRIPTION
# Description

Code Climate is configured to complain if any function contains more than 50 lines. The Knex Migration file `exports.up` function contained 95 lines due to chained method calls being unwrapped onto multiple lines. This change tightens those calls to get the function under the 50 line limit so Code Climate will stop complaining.

There are no functional changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Performed Knex Migration down and up, then re-ran seeds.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
