### PR TITLE
Add build notification email action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on: [push, pull_request]
 
 # The jobs that will be run, usually in parallel
 jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Send a build notification email
+    - name: Send email
+      uses: dawidd6/action-send-mail@v2.2.0
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.MAIL_USERNAME}}
+        password: ${{secrets.MAIL_PASSWORD}}
+        subject: Github Actions build result
+        body: Build job of ${{github.repository}} completed!
+        to: ${{secrets.BUILD_NOTICE_RECIPIENTS}}
+        from: Neighborhood Chef <${{secrets.MAIL_USERNAME}}>
+        # Optional content type (defaults to text/plain):
+        content_type: text/html
+
   # A job to generate and publish code coverage
   coverage:
     # A more descriptive name of the job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,6 @@ on: [push, pull_request]
 
 # The jobs that will be run, usually in parallel
 jobs:
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
-
-    # Send a build notification email
-    - name: Send email
-      uses: dawidd6/action-send-mail@v2.2.0
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.MAIL_USERNAME}}
-        password: ${{secrets.MAIL_PASSWORD}}
-        subject: Github Actions build result
-        body: Build job of ${{github.repository}} completed!
-        to: ${{secrets.BUILD_NOTICE_RECIPIENTS}}
-        from: Neighborhood Chef <${{secrets.MAIL_USERNAME}}>
-        # Optional content type (defaults to text/plain):
-        content_type: text/html
-
   # A job to generate and publish code coverage
   coverage:
     # A more descriptive name of the job
@@ -58,3 +34,18 @@ jobs:
           coverageCommand: npm run coverage
           # By default, this looks for a `coverage` folder in the root of your project, but you may need to change this
           debug: true
+
+      # Send a build notification email
+      - name: Send email
+        uses: dawidd6/action-send-mail@v2.2.0
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          subject: Github Actions build result
+          body: Build job of ${{github.repository}} completed!
+          to: ${{secrets.BUILD_NOTICE_RECIPIENTS}}
+          from: Neighborhood Chef <${{secrets.MAIL_USERNAME}}>
+          # Optional content type (defaults to text/plain):
+          content_type: text/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,21 @@ jobs:
       - name: Send email
         uses: dawidd6/action-send-mail@v2.2.0
         with:
+          # SMTP server address
           server_address: smtp.gmail.com
+          # SMTP server port
           server_port: 465
+          # Authenticate as this user to SMTP server
           username: ${{secrets.MAIL_USERNAME}}
+          # Authenticate with this password to SMTP server
           password: ${{secrets.MAIL_PASSWORD}}
+          # Subject of mail message
           subject: Github Actions build result
+          # Body of mail message (might be a filename prefixed with file:// to read from)
           body: Build job of ${{github.repository}} completed!
+          # Recipients mail addresses (separated with comma)
           to: ${{secrets.BUILD_NOTICE_RECIPIENTS}}
+          # Full name of mail sender (might be with an email address specified in <>)
           from: Neighborhood Chef <${{secrets.MAIL_USERNAME}}>
           # Optional content type (defaults to text/plain):
           content_type: text/html


### PR DESCRIPTION
# Description

Add's a Build Notification Email to the CI Actions.

~~WARNING: Please do NOT merge this until @Shadowborn confirms the requested GitHub Secrets have been added to this Repository!~~
Secrets are verified added and working.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
