### PR TITLE
Add more environments to gitignore dotenv patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,10 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.dev*
+.env.test*
+.env.stag*
+.env.prod*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
# Description

Just adds some .env.* file patterns to cover various environments we might want to maintain separate settings for.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Confirmed local `.env`, `.env.dev`, `.env.prod` files are all ignored from being checked into git.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
