### PR TITLE
BACKEND_BASE_URL env var fix

### DIFF
--- a/.ebextensions/00_create_env_file.config
+++ b/.ebextensions/00_create_env_file.config
@@ -24,7 +24,7 @@ files:
       OKTA_BASE_URL=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"OKTA_BASE_URL"}}`
       OKTA_GROUP_ID=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"OKTA_GROUP_ID"}}`
       PASSWORD_CHANGE_REDIRECT=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"PASSWORD_CHANGE_REDIRECT"}}`
-      BACKEND_BASE_URL=https://be.ourneighborhoodchef.com
+      BACKEND_BASE_URL=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"BACKEND_BASE_URL"}}`
 container_commands:
   00a_list_file_in_tmp:
     command: "ls -lh /tmp/.env.prod"

--- a/.ebextensions/00_create_env_file.config
+++ b/.ebextensions/00_create_env_file.config
@@ -24,6 +24,7 @@ files:
       OKTA_BASE_URL=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"OKTA_BASE_URL"}}`
       OKTA_GROUP_ID=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"OKTA_GROUP_ID"}}`
       PASSWORD_CHANGE_REDIRECT=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"PASSWORD_CHANGE_REDIRECT"}}`
+      BACKEND_BASE_URL=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"BACKEND_BASE_URL"}}`
 container_commands:
   00a_list_file_in_tmp:
     command: "ls -lh /tmp/.env.prod"

--- a/.ebextensions/00_create_env_file.config
+++ b/.ebextensions/00_create_env_file.config
@@ -28,16 +28,16 @@ files:
 container_commands:
   00a_list_file_in_tmp:
     command: "ls -lh /tmp/.env.prod"
-    test: [ -f /tmp/.env.prod ]
+    test: '[ -f /tmp/.env.prod ]'
   00b_show_file_contents_in_tmp:
     command: "cat /tmp/.env.prod"
-    test: [ -f /tmp/.env.prod ]
+    test: '[ -f /tmp/.env.prod ]'
   00c_move_env_file:
     command: "mv /tmp/.env.prod /var/app/staging/.env"
-    test: [ -f /tmp/.env.prod ] && [ -d /var/app/staging ]
+    test: '[ -f /tmp/.env.prod ] && [ -d /var/app/staging ]'
   00d_list_file_in_app:
     command: "ls -lh /var/app/staging/.env"
-    test: [ -f /var/app/staging/.env ]
+    test: '[ -f /var/app/staging/.env ]'
   00e_show_file_contents_in_app:
     command: "cat /var/app/staging/.env"
-    test: [ -f /var/app/staging/.env ]
+    test: '[ -f /var/app/staging/.env ]'

--- a/.ebextensions/00_create_env_file.config
+++ b/.ebextensions/00_create_env_file.config
@@ -28,11 +28,16 @@ files:
 container_commands:
   00a_list_file_in_tmp:
     command: "ls -lh /tmp/.env.prod"
+    test: [ -f /tmp/.env.prod ]
   00b_show_file_contents_in_tmp:
     command: "cat /tmp/.env.prod"
+    test: [ -f /tmp/.env.prod ]
   00c_move_env_file:
     command: "mv /tmp/.env.prod /var/app/staging/.env"
+    test: [ -f /tmp/.env.prod ] && [ -d /var/app/staging ]
   00d_list_file_in_app:
     command: "ls -lh /var/app/staging/.env"
+    test: [ -f /var/app/staging/.env ]
   00e_show_file_contents_in_app:
     command: "cat /var/app/staging/.env"
+    test: [ -f /var/app/staging/.env ]

--- a/.ebextensions/00_create_env_file.config
+++ b/.ebextensions/00_create_env_file.config
@@ -24,7 +24,7 @@ files:
       OKTA_BASE_URL=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"OKTA_BASE_URL"}}`
       OKTA_GROUP_ID=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"OKTA_GROUP_ID"}}`
       PASSWORD_CHANGE_REDIRECT=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"PASSWORD_CHANGE_REDIRECT"}}`
-      BACKEND_BASE_URL=`{"Fn::GetOptionSetting":{"Namespace":"aws:elasticbeanstalk:application:environment","OptionName":"BACKEND_BASE_URL"}}`
+      BACKEND_BASE_URL=https://be.ourneighborhoodchef.com
 container_commands:
   00a_list_file_in_tmp:
     command: "ls -lh /tmp/.env.prod"

--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,4 +1,6 @@
 branch-defaults:
+  feature/backend_base_url-env-var:
+    environment: NeighborhoodChefBE-prod
   feature/database-setup_elastic-beanstalk:
     environment: NeighborhoodChefBE-prod
   feature/https-instance_config:

--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,4 @@ OKTA_API_TOKEN=tokenstring
 OKTA_BASE_URL=orgdomain
 OKTA_GROUP_ID=idofusergroup
 PASSWORD_CHANGE_REDIRECT=http://facebook.com
-BACKEND_BASE_URL=localhost:123245
-
+BACKEND_BASE_URL=http://localhost:123245


### PR DESCRIPTION
# Description

Fixes the backend failing to start due to the paradox of the code trying to use the BACKEND_BASE_URL environment variable which hasn't yet been defined, but the variable not being able to be defined because the code is demanding it... Had to trick AWS to get it to work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Manually tested via SSH to confirm the variable is correctly written in the `.env` file.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
