### PR TITLE
feature/persist-comment-reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ If prompted for a password, input your currently logged-in user's password to pe
 
 #### Comments
 
-| Type     | Name                  | variables                          | Description               |
-| -------- | --------------------- | ---------------------------------- | ------------------------- |
-| Query    | getEventComments      | (id: ID!)                          | Returns all event comments|
-| Mutation | addComment | (id: ID!)| (input: !NewCommentInput)          | Returns create comment    |
-| Mutation | updateComment         | (id: ID!, input: !NewCommentInput) | Returns updated comment   |
-| Mutation | removeComment         |(id: ID!) | Returns deleted comment | Returns deleted comment   |
+| Type     | Name                  | variables                          | Description                                    |
+| -------- | --------------------- | ---------------------------------- | ---------------------------------------------- |
+| Query    | getEventComments      | (id: ID!)                          | Returns all event comments                     |
+| Query    | getCommentReactions   | (id: ID!)                          | Returns all comment reactions                  |
+| Mutation | addComment | (id: ID!)| (input: !NewCommentInput)          | Returns create comment                         |
+| Mutation | updateComment         | (id: ID!, input: !NewCommentInput) | Returns updated comment                        |
+| Mutation | removeComment         | (id: ID!)                          | Returns deleted comment                        |
+| Mutation | handleReaction        | (input: ReactionInput!)            | Dynamically adds, updates, or deletes reaction |
 
 #### Event Ingredients
 
@@ -338,7 +340,7 @@ If prompted for a password, input your currently logged-in user's password to pe
     user_id: Int
   }
 ```
-#### comment Type and Inputs
+#### comment/reactions Type and Inputs
 
 ```graphql
   type Comment {
@@ -369,7 +371,7 @@ If prompted for a password, input your currently logged-in user's password to pe
   input UpdateCommentInput {
     id: ID
     event_id: Int
-    user_id: Int!
+    user_id: Int
     parent_id: Int
     root_id: Int
     dateCreated: String
@@ -377,6 +379,21 @@ If prompted for a password, input your currently logged-in user's password to pe
   }
 ```
 
+```graphql
+type Reaction {
+    comment_id: Int!
+    user_id: Int!
+    reaction: String!
+  }
+```
+
+```graphql
+  input ReactionInput {
+    comment_id: Int!
+    user_id: Int!
+    reaction: String!
+  }
+```
 
 ## Environment Variables
 

--- a/data/migrations/20200626084713_comment_reactions.js
+++ b/data/migrations/20200626084713_comment_reactions.js
@@ -1,0 +1,15 @@
+
+exports.up = function (knex) {
+    return knex.schema
+        .createTable('Comment_Reactions', tbl => {
+            tbl.integer('comment_id').notNullable().unsigned().references('Comments.id').onUpdate('CASCADE').onDelete('CASCADE');
+            tbl.integer('user_id').notNullable().unsigned().references('Users.id').onUpdate('CASCADE').onDelete('CASCADE');
+            tbl.enum('reaction', ['heart', 'thumbsUp', 'thumbsDown', 'Happy', 'Laugh', 'Sad', 'Angry']).notNullable();
+            tbl.primary(['comment_id', 'user_id']);
+        })
+};
+
+exports.down = function (knex) {
+    return knex.schema
+        .dropTableIfExists('Comment_Reactions')
+};

--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -46,6 +46,8 @@ const {
   addComment,
   updateComment,
   removeComment,
+  handleReaction,
+  getCommentReactions,
 } = require("../resolvers/comments/comment-resolvers.js");
 
 module.exports = {
@@ -66,6 +68,7 @@ module.exports = {
     getFavoriteEvents,
     getIngredientsByEventId,
     getEventComments,
+    getCommentReactions,
 
   },
   Mutation: {
@@ -87,5 +90,6 @@ module.exports = {
     addComment,
     updateComment,
     removeComment,
+    handleReaction,
   },
 };

--- a/src/graphql/schemas.js
+++ b/src/graphql/schemas.js
@@ -214,6 +214,18 @@ const typeDefs = gql`
     comment: String
   }
 
+  type Reaction {
+    comment_id: Int!
+    user_id: Int!
+    reaction: String!
+  }
+
+  input ReactionInput {
+    comment_id: Int!
+    user_id: Int!
+    reaction: String!
+  }
+
   type Query {
     status: String!
     getAllUsers: [User]!
@@ -230,6 +242,7 @@ const typeDefs = gql`
     getFavoriteEvents(id: ID!): [Event]!
     getIngredientsByEventId(event_id: Int!): [EventIngredient]!
     getEventComments(id: ID!): [Comment]!
+    getCommentReactions(id: ID!): [Reaction]!
   }
 
   type Mutation {
@@ -251,6 +264,7 @@ const typeDefs = gql`
     addComment(input: NewCommentInput!): Comment!
     updateComment(id: ID!, input: UpdateCommentInput!): Comment!
     removeComment(id: ID!): Comment!
+    handleReaction(input: ReactionInput!): [Reaction]!
   }
 `;
 

--- a/src/models/comment-reactions/reaction-models.js
+++ b/src/models/comment-reactions/reaction-models.js
@@ -1,0 +1,44 @@
+const db = require("../../../data/dbConfig.js");
+
+module.exports = {
+    findAllCommentReactions,
+    findBy,
+    add,
+    update,
+    remove,
+};
+
+function findAllCommentReactions(id) {
+    return db("Comment_Reactions").where("comment_id", id);
+}
+
+function findBy(filter) {
+    return db("Comment_Reactions")
+        .where("comment_id", filter.comment_id)
+        .andWhere("user_id", filter.user_id)
+}
+
+async function add(input) {
+    const reaction = await db("Comment_Reactions").insert(input)
+
+    return findAllCommentReactions(input.comment_id)
+}
+
+async function update(changes) {
+    const updated = await db("Comment_Reactions")
+        .where("comment_id", changes.comment_id)
+        .andWhere("user_id", changes.user_id)
+        .update(changes)
+        .returning("comment_id")
+
+    return await findAllCommentReactions(changes.comment_id)
+}
+
+async function remove(reaction) {
+    const deleted = await db("Comment_Reactions")
+        .where("comment_id", reaction.comment_id)
+        .andWhere("user_id", reaction.user_id)
+        .del();
+
+    return await findAllCommentReactions(reaction.comment_id)
+}


### PR DESCRIPTION
# Description
These changes allow comment reactions to persist on backend. I ended up simplifying things mostly using a single a resolver to either add, update or delete a user's reaction.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

In graphql and locally in the browser.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
